### PR TITLE
getPostsでパラメータ検索ができるように

### DIFF
--- a/database/post.go
+++ b/database/post.go
@@ -51,15 +51,14 @@ func (r *PostRepository) Store(post *entity.Post) error {
 	return nil
 }
 
-func (r *PostRepository) FindAll(offset, pageSize int) (posts []*entity.Post, err error) {
-	if err = r.db.Debug().Offset(offset).Limit(pageSize).Find(&posts).Error; err != nil {
+func (r *PostRepository) FindAll(offset, pageSize int, condition string, params []interface{}) (posts []*entity.Post, err error) {
+	if err = r.db.Where(condition, params...).Offset(offset).Limit(pageSize).Find(&posts).Error; err != nil {
 		err = fmt.Errorf("find all posts: %w", err)
+		return
 	}
 	if len(posts) == 0 {
 		err = fmt.Errorf("find all posts: %w", entity.ErrPostNotFound)
-	}
-	for _, v := range posts {
-		fmt.Println(v)
+		return
 	}
 	return
 }

--- a/database/post_test.go
+++ b/database/post_test.go
@@ -249,6 +249,8 @@ func TestPostRepository_FindAll(t *testing.T) {
 		existPosts []*entity.Post
 		offset     int
 		pageSize   int
+		condition  string
+		params     []interface{}
 		want       []*entity.Post
 		wantErr    error
 	}{
@@ -285,8 +287,10 @@ func TestPostRepository_FindAll(t *testing.T) {
 				UpdatedAt:    flextime.Now(),
 				PublishedAt:  flextime.Now(),
 			}},
-			offset:   0,
-			pageSize: 0,
+			offset:    0,
+			pageSize:  0,
+			condition: "",
+			params:    []interface{}{},
 			want: []*entity.Post{{
 				ID:           "abcdefghijklmnopqrstuvwxy1",
 				Title:        "new_post",
@@ -352,8 +356,10 @@ func TestPostRepository_FindAll(t *testing.T) {
 				UpdatedAt:    flextime.Now(),
 				PublishedAt:  flextime.Now(),
 			}},
-			offset:   1,
-			pageSize: 2,
+			offset:    1,
+			pageSize:  2,
+			condition: "",
+			params:    []interface{}{},
 			want: []*entity.Post{{
 				ID:           "abcdefghijklmnopqrstuvwxy2",
 				Title:        "new_post",
@@ -376,7 +382,57 @@ func TestPostRepository_FindAll(t *testing.T) {
 				PublishedAt:  flextime.Now(),
 			}},
 			wantErr: nil,
+		}, {
+			name: "is_draftパラメータを適用して取得できる",
+			existPosts: []*entity.Post{{
+				ID:           "abcdefghijklmnopqrstuvwxy1",
+				Title:        "new_post",
+				ThumbnailURL: "new_thumbnail_url",
+				Content:      "new_content",
+				Permalink:    "new_permalink",
+				IsDraft:      false,
+				CreatedAt:    flextime.Now(),
+				UpdatedAt:    flextime.Now(),
+				PublishedAt:  flextime.Now(),
+			}, {
+				ID:           "abcdefghijklmnopqrstuvwxy2",
+				Title:        "new_post",
+				ThumbnailURL: "new_thumbnail_url",
+				Content:      "new_content",
+				Permalink:    "new_permalink2",
+				IsDraft:      false,
+				CreatedAt:    flextime.Now(),
+				UpdatedAt:    flextime.Now(),
+				PublishedAt:  flextime.Now(),
+			}, {
+				ID:           "abcdefghijklmnopqrstuvwxy3",
+				Title:        "new_post",
+				ThumbnailURL: "new_thumbnail_url",
+				Content:      "new_content",
+				Permalink:    "new_permalink3",
+				IsDraft:      true,
+				CreatedAt:    flextime.Now(),
+				UpdatedAt:    flextime.Now(),
+				PublishedAt:  flextime.Now(),
+			}},
+			offset:    0,
+			pageSize:  0,
+			condition: "is_draft = ?",
+			params:    []interface{}{true},
+			want: []*entity.Post{{
+				ID:           "abcdefghijklmnopqrstuvwxy3",
+				Title:        "new_post",
+				ThumbnailURL: "new_thumbnail_url",
+				Content:      "new_content",
+				Permalink:    "new_permalink3",
+				IsDraft:      true,
+				CreatedAt:    flextime.Now(),
+				UpdatedAt:    flextime.Now(),
+				PublishedAt:  flextime.Now(),
+			}},
+			wantErr: nil,
 		},
+
 		{
 			name:       "投稿が存在しない場合はErrPostNotFoundを返す",
 			existPosts: nil,
@@ -394,7 +450,7 @@ func TestPostRepository_FindAll(t *testing.T) {
 			}
 
 			r := &PostRepository{db: tx}
-			got, err := r.FindAll(tt.offset, tt.pageSize)
+			got, err := r.FindAll(tt.offset, tt.pageSize, tt.condition, tt.params)
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("FindAll()  error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/domain/entity/error.go
+++ b/domain/entity/error.go
@@ -6,6 +6,7 @@ import "errors"
 // エラー: 1062 SQLSTATE: 23000 (ER_DUP_ENTRY)
 
 var (
+	ErrInternalServerError = errors.New("internal server error")
 	// ErrUserNotFound はユーザが存在しないエラーを表します。
 	ErrUserNotFound = errors.New("user not found")
 	// ErrUserAlreadyExisted はユーザが既に存在しているエラーを表します。

--- a/domain/mock_repository/post.go
+++ b/domain/mock_repository/post.go
@@ -49,18 +49,18 @@ func (mr *MockPostMockRecorder) FindByID(id interface{}) *gomock.Call {
 }
 
 // FindAll mocks base method
-func (m *MockPost) FindAll(offset, pageSize int) ([]*entity.Post, error) {
+func (m *MockPost) FindAll(offset, pageSize int, conditions string, params []interface{}) ([]*entity.Post, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindAll", offset, pageSize)
+	ret := m.ctrl.Call(m, "FindAll", offset, pageSize, conditions, params)
 	ret0, _ := ret[0].([]*entity.Post)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindAll indicates an expected call of FindAll
-func (mr *MockPostMockRecorder) FindAll(offset, pageSize interface{}) *gomock.Call {
+func (mr *MockPostMockRecorder) FindAll(offset, pageSize, conditions, params interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAll", reflect.TypeOf((*MockPost)(nil).FindAll), offset, pageSize)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAll", reflect.TypeOf((*MockPost)(nil).FindAll), offset, pageSize, conditions, params)
 }
 
 // FindByPermalink mocks base method

--- a/domain/repository/post.go
+++ b/domain/repository/post.go
@@ -4,7 +4,7 @@ import "github.com/masibw/blog-server/domain/entity"
 
 type Post interface {
 	FindByID(id string) (*entity.Post, error)
-	FindAll(offset, pageSize int) ([]*entity.Post, error)
+	FindAll(offset, pageSize int, conditions string, params []interface{}) ([]*entity.Post, error)
 	FindByPermalink(permalink string) (*entity.Post, error)
 	Store(post *entity.Post) error
 	Delete(id string) error

--- a/usecase/post.go
+++ b/usecase/post.go
@@ -47,9 +47,9 @@ func (p *PostUseCase) StorePost(postDTO *dto.PostDTO) (*dto.PostDTO, error) {
 	return post.ConvertToDTO(), nil
 }
 
-func (p *PostUseCase) GetPosts(offset, pageSize int) (postDTOs []*dto.PostDTO, err error) {
+func (p *PostUseCase) GetPosts(offset, pageSize int, condition string, params []interface{}) (postDTOs []*dto.PostDTO, err error) {
 	var posts []*entity.Post
-	posts, err = p.postRepository.FindAll(offset, pageSize)
+	posts, err = p.postRepository.FindAll(offset, pageSize, condition, params)
 	if err != nil {
 		err = fmt.Errorf("get posts: %w", err)
 		return

--- a/usecase/post_test.go
+++ b/usecase/post_test.go
@@ -174,7 +174,7 @@ func TestPostUseCase_GetPosts(t *testing.T) {
 		{
 			name: "postDTOsを返すこと",
 			prepareMockPostRepoFn: func(mock *mock_repository.MockPost) {
-				mock.EXPECT().FindAll(gomock.Any(), gomock.Any()).Return(existsPosts, nil)
+				mock.EXPECT().FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(existsPosts, nil)
 			},
 			want: []*dto.PostDTO{
 				{
@@ -205,7 +205,7 @@ func TestPostUseCase_GetPosts(t *testing.T) {
 		{
 			name: "FindAllがエラーを返した時はpostDTOsが空であること",
 			prepareMockPostRepoFn: func(mock *mock_repository.MockPost) {
-				mock.EXPECT().FindAll(gomock.Any(), gomock.Any()).Return(nil, errors.New("dummy error"))
+				mock.EXPECT().FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, errors.New("dummy error"))
 			},
 			want:    nil,
 			wantErr: true,
@@ -222,7 +222,8 @@ func TestPostUseCase_GetPosts(t *testing.T) {
 				postRepository: mr,
 			}
 
-			got, err := p.GetPosts(0, 0)
+			// このGetPostsの責務はパラメータを受け取ってpostDTOsを返すだけなのでパラメータの中身はなんでも良い(はず)
+			got, err := p.GetPosts(0, 0, "", []interface{}{})
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetPosts() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
`GET /api/v1/posts?page=2&page_size=3&is_draft=true`ができるようになりました

FindAllBy〇〇みたいなのを作ろうかと思ったけどメソッドが爆発しそうだったので動的にクエリを生成するように変更