### PR TITLE
投稿の更新API

### DIFF
--- a/database/post.go
+++ b/database/post.go
@@ -51,6 +51,13 @@ func (r *PostRepository) Store(post *entity.Post) error {
 	return nil
 }
 
+func (r *PostRepository) Update(post *entity.Post) error {
+	if err := r.db.Updates(post).Error; err != nil {
+		return fmt.Errorf("update post: %w", err)
+	}
+	return nil
+}
+
 func (r *PostRepository) FindAll(offset, pageSize int, condition string, params []interface{}) (posts []*entity.Post, err error) {
 	if err = r.db.Where(condition, params...).Offset(offset).Limit(pageSize).Find(&posts).Error; err != nil {
 		err = fmt.Errorf("find all posts: %w", err)

--- a/database/post_test.go
+++ b/database/post_test.go
@@ -114,6 +114,56 @@ func TestPostRepository_FindByID(t *testing.T) {
 	tx.Rollback()
 }
 
+func TestPostRepository_Update(t *testing.T) {
+	tx := db.Begin()
+
+	if err := tx.Create(&entity.Post{
+		ID:           "abcdefghijklmnopqrstuvwxyz",
+		Title:        "new_post",
+		ThumbnailURL: "new_thumbnail_url",
+		Content:      "new_content",
+		Permalink:    "new_permalink",
+		IsDraft:      false,
+		CreatedAt:    flextime.Now(),
+		UpdatedAt:    flextime.Now(),
+		PublishedAt:  flextime.Now(),
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		post    *entity.Post
+		wantErr error
+	}{
+		{
+			name: "投稿を正常に更新できる",
+			post: &entity.Post{
+				ID:           "abcdefghijklmnopqrstuvwxyz",
+				Title:        "new_post",
+				ThumbnailURL: "new_thumbnail_url",
+				Content:      "new_content2",
+				Permalink:    "new_permalink",
+				IsDraft:      false,
+				CreatedAt:    time.Time{},
+				UpdatedAt:    time.Time{},
+				PublishedAt:  time.Time{},
+			},
+			wantErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &PostRepository{db: tx}
+			if err := r.Update(tt.post); !errors.Is(err, tt.wantErr) {
+				t.Errorf("Store() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+
+	tx.Rollback()
+}
 func TestPostRepository_Store(t *testing.T) {
 	tx := db.Begin()
 

--- a/docs/schema/posts.md
+++ b/docs/schema/posts.md
@@ -10,14 +10,13 @@ CREATE TABLE `posts` (
   `id` char(26) COLLATE utf8mb4_unicode_ci NOT NULL,
   `title` varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `thumbnail_url` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `content` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `permalink` varchar(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `content` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `permalink` varchar(256) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `is_draft` tinyint(1) NOT NULL DEFAULT '0',
   `created_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `published_at` datetime DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `permalink` (`permalink`)
+  PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
 ```
 
@@ -30,8 +29,8 @@ CREATE TABLE `posts` (
 | id | char(26) |  | false |  | [posts_tags](posts_tags.md) |  |  |
 | title | varchar(64) |  | true |  |  |  |  |
 | thumbnail_url | text |  | false |  |  |  |  |
-| content | longtext |  | false |  |  |  |  |
-| permalink | varchar(256) |  | false |  |  |  |  |
+| content | longtext |  | true |  |  |  |  |
+| permalink | varchar(256) |  | true |  |  |  |  |
 | is_draft | tinyint(1) | 0 | false |  |  |  |  |
 | created_at | datetime | CURRENT_TIMESTAMP | false | DEFAULT_GENERATED |  |  |  |
 | updated_at | datetime | CURRENT_TIMESTAMP | false | DEFAULT_GENERATED on update CURRENT_TIMESTAMP |  |  |  |
@@ -41,7 +40,6 @@ CREATE TABLE `posts` (
 
 | Name | Type | Definition |
 | ---- | ---- | ---------- |
-| permalink | UNIQUE | UNIQUE KEY permalink (permalink) |
 | PRIMARY | PRIMARY KEY | PRIMARY KEY (id) |
 
 ## Indexes
@@ -49,7 +47,6 @@ CREATE TABLE `posts` (
 | Name | Definition |
 | ---- | ---------- |
 | PRIMARY | PRIMARY KEY (id) USING BTREE |
-| permalink | UNIQUE KEY permalink (permalink) USING BTREE |
 
 ## Relations
 

--- a/domain/dto/post.go
+++ b/domain/dto/post.go
@@ -1,6 +1,8 @@
 package dto
 
-import "time"
+import (
+	"time"
+)
 
 type PostDTO struct {
 	ID           string    `json:"id"`

--- a/domain/entity/error.go
+++ b/domain/entity/error.go
@@ -18,6 +18,8 @@ var (
 	ErrPostAlreadyExisted = errors.New("post has already existed")
 	// ErrPermalinkAlreadyExisted はパーマリンクが既に存在しているエラーを表します。
 	ErrPermalinkAlreadyExisted = errors.New("permalink has already existed")
+	// ErrPostHasEmptyField は投稿に未入力項目があるエラーを表します。
+	ErrPostHasEmptyField = errors.New("some fields that have not been filled")
 
 	// ErrTagNotFound はタグが存在しないエラーを表します。
 	ErrTagNotFound = errors.New("tag not found")

--- a/domain/entity/post.go
+++ b/domain/entity/post.go
@@ -51,6 +51,18 @@ func (p *Post) ConvertToDTO() *dto.PostDTO {
 	}
 }
 
+func (p *Post) ConvertFromDTO(postDTO *dto.PostDTO) {
+	p.ID = postDTO.ID
+	p.Title = postDTO.Title
+	p.ThumbnailURL = postDTO.ThumbnailURL
+	p.Content = postDTO.Content
+	p.Permalink = postDTO.Permalink
+	p.IsDraft = *postDTO.IsDraft
+	p.UpdatedAt = postDTO.UpdatedAt
+	p.CreatedAt = postDTO.CreatedAt
+	p.PublishedAt = postDTO.PublishedAt
+}
+
 func (p *Post) ConvertContentToHTML() {
 	bytesContent := *(*[]byte)(unsafe.Pointer(&p.Content))
 	unsafeHTML := blackfriday.Run(bytesContent)

--- a/domain/mock_repository/post.go
+++ b/domain/mock_repository/post.go
@@ -92,6 +92,20 @@ func (mr *MockPostMockRecorder) Store(post interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Store", reflect.TypeOf((*MockPost)(nil).Store), post)
 }
 
+// Update mocks base method
+func (m *MockPost) Update(post *entity.Post) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Update", post)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Update indicates an expected call of Update
+func (mr *MockPostMockRecorder) Update(post interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockPost)(nil).Update), post)
+}
+
 // Delete mocks base method
 func (m *MockPost) Delete(id string) error {
 	m.ctrl.T.Helper()

--- a/domain/repository/post.go
+++ b/domain/repository/post.go
@@ -7,5 +7,6 @@ type Post interface {
 	FindAll(offset, pageSize int, conditions string, params []interface{}) ([]*entity.Post, error)
 	FindByPermalink(permalink string) (*entity.Post, error)
 	Store(post *entity.Post) error
+	Update(post *entity.Post) error
 	Delete(id string) error
 }

--- a/migrations/000007_schema.down.sql
+++ b/migrations/000007_schema.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE posts modify permalink VARCHAR(256) COLLATE utf8mb4_unicode_ci NOT NULL;
+ALTER TABLE posts modify LONGTEXT COLLATE utf8mb4_unicode_ci NOT NULL;
+ALTER TABLE posts ADD UNIQUE permalink;

--- a/migrations/000007_schema.up.sql
+++ b/migrations/000007_schema.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE posts modify permalink VARCHAR(256) COLLATE utf8mb4_unicode_ci;
+ALTER TABLE posts modify content LONGTEXT COLLATE utf8mb4_unicode_ci;
+ALTER TABLE posts DROP INDEX permalink;

--- a/usecase/post.go
+++ b/usecase/post.go
@@ -47,6 +47,65 @@ func (p *PostUseCase) StorePost(postDTO *dto.PostDTO) (*dto.PostDTO, error) {
 	return post.ConvertToDTO(), nil
 }
 
+func (p *PostUseCase) UpdatePost(postDTO *dto.PostDTO) (*dto.PostDTO, error) {
+
+	// 下書きじゃないのにTitleとContent,Permalinkに未入力項目があればエラー
+	if !*postDTO.IsDraft {
+		errMsg := ""
+		if postDTO.Title == "" {
+			errMsg += "title is nil "
+		}
+		if postDTO.Content == "" {
+			errMsg += "content is nil "
+		}
+		if postDTO.Permalink == "" {
+			errMsg += "permalink is nil "
+		}
+		if errMsg != "" {
+			return nil, fmt.Errorf("update post some fields that have not been filled %s: %w", errMsg, entity.ErrPostHasEmptyField)
+		}
+	}
+
+	var post *entity.Post
+	var err error
+
+	// 更新対象の投稿が存在するかの確認
+	post, err = p.postRepository.FindByID(postDTO.ID)
+	if err != nil && !errors.Is(err, entity.ErrPostNotFound) {
+		return nil, fmt.Errorf("update post title=%v: %w", postDTO.Title, err)
+	}
+	if errors.Is(err, entity.ErrPostNotFound) {
+		return nil, fmt.Errorf("update post not found ID=%v: %w", postDTO.ID, entity.ErrPostNotFound)
+	}
+
+	var permalinkPost *entity.Post
+	// 重複確認の処理をDomainServiceに切り出すべきだけど2箇所なので一旦保留
+	permalinkPost, err = p.postRepository.FindByPermalink(postDTO.Permalink)
+	if err != nil && !errors.Is(err, entity.ErrPostNotFound) {
+		return nil, fmt.Errorf("update post title=%v: %w", postDTO.Title, err)
+	}
+
+	// 更新する投稿と違うIDを持ち，既に更新先Permalinkを持つ投稿があるとエラー
+	if permalinkPost != nil && permalinkPost.ID != postDTO.ID {
+		return nil, fmt.Errorf("update post permalink=%v: %w", postDTO.Permalink, entity.ErrPermalinkAlreadyExisted)
+	}
+
+	post.ConvertFromDTO(postDTO)
+
+	// 初めて公開するときのみ投稿時間を設定する
+	if post.PublishedAt.IsZero() && !post.IsDraft {
+		post.PublishedAt = flextime.Now()
+	}
+
+	err = p.postRepository.Update(post)
+
+	if err != nil {
+		return nil, fmt.Errorf("update post title=%v: %w", postDTO.Title, err)
+	}
+
+	return post.ConvertToDTO(), nil
+}
+
 func (p *PostUseCase) GetPosts(offset, pageSize int, condition string, params []interface{}) (postDTOs []*dto.PostDTO, err error) {
 	var posts []*entity.Post
 	posts, err = p.postRepository.FindAll(offset, pageSize, condition, params)

--- a/web/router.go
+++ b/web/router.go
@@ -27,6 +27,7 @@ func NewServer(postUC *usecase.PostUseCase, tagUC *usecase.TagUseCase) (e *gin.E
 	posts.GET("", postHandler.GetPosts)
 	posts.POST("", postHandler.StorePost)
 	posts.GET(":id", postHandler.GetPost)
+	posts.PUT(":id", postHandler.UpdatePost)
 	posts.DELETE(":id", postHandler.DeletePost)
 
 	tags := v1.Group("/tags")


### PR DESCRIPTION
`PUT api/v1/posts/:id`
投稿を更新します．

CREATEを空投稿を作成するだけに変更するのを別PRで出す, IDとThumbnailURLをデフォルト値入れて返す
UPDATEはTitleとContentとPermalinkは下書きならnull更新OK, 公開ならnull更新NGでエラーを返す


