### PR TITLE
空の投稿を作成するだけに変更

### DIFF
--- a/constant/constant.go
+++ b/constant/constant.go
@@ -1,0 +1,6 @@
+package constant
+
+// TODO 画像の投稿を実装したらデフォルト画像のURLを入れる
+
+// DefaultThumbnailURL はサムネイルのデフォルトURLです
+var DefaultThumbnailURL = "default_url"

--- a/database/post.go
+++ b/database/post.go
@@ -41,7 +41,7 @@ func (r *PostRepository) FindByPermalink(permalink string) (*entity.Post, error)
 	return post, nil
 }
 
-func (r *PostRepository) Store(post *entity.Post) error {
+func (r *PostRepository) Create(post *entity.Post) error {
 	if err := r.db.Create(post).Error; err != nil {
 		if mysqlErr, ok := err.(*mysql.MySQLError); ok && mysqlErr.Number == 1062 {
 			return fmt.Errorf("create post: %w", entity.ErrPostAlreadyExisted)

--- a/database/post_test.go
+++ b/database/post_test.go
@@ -157,7 +157,7 @@ func TestPostRepository_Update(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &PostRepository{db: tx}
 			if err := r.Update(tt.post); !errors.Is(err, tt.wantErr) {
-				t.Errorf("Store() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Create() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}
@@ -207,8 +207,8 @@ func TestPostRepository_Store(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &PostRepository{db: tx}
-			if err := r.Store(tt.post); !errors.Is(err, tt.wantErr) {
-				t.Errorf("Store() error = %v, wantErr %v", err, tt.wantErr)
+			if err := r.Create(tt.post); !errors.Is(err, tt.wantErr) {
+				t.Errorf("Create() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/database/posts_tags_test.go
+++ b/database/posts_tags_test.go
@@ -169,7 +169,7 @@ func TestPostsTagsRepository_Store(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &PostsTagsRepository{db: tx}
 			if err := r.Store(tt.postTags); !errors.Is(err, tt.wantErr) {
-				t.Errorf("Store() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Create() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/database/tag_test.go
+++ b/database/tag_test.go
@@ -109,7 +109,7 @@ func TestTagRepository_Store(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &TagRepository{db: tx}
 			if err := r.Store(tt.tag); !errors.Is(err, tt.wantErr) {
-				t.Errorf("Store() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Create() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/domain/entity/post.go
+++ b/domain/entity/post.go
@@ -7,6 +7,7 @@ import (
 	"github.com/microcosm-cc/bluemonday"
 	"github.com/russross/blackfriday/v2"
 
+	"github.com/masibw/blog-server/constant"
 	"github.com/masibw/blog-server/util"
 
 	"github.com/Songmu/flextime"
@@ -25,14 +26,14 @@ type Post struct {
 	PublishedAt  time.Time
 }
 
-func NewPost(title string, thumbnailURL string, content string, permalink string, isDraft bool) *Post {
+func NewPost() *Post {
 	return &Post{
 		ID:           util.Generate(flextime.Now()),
-		Title:        title,
-		ThumbnailURL: thumbnailURL,
-		Content:      content,
-		Permalink:    permalink,
-		IsDraft:      isDraft,
+		Title:        "",
+		ThumbnailURL: constant.DefaultThumbnailURL,
+		Content:      "",
+		Permalink:    "",
+		IsDraft:      true,
 		PublishedAt:  time.Time{},
 	}
 }

--- a/domain/mock_repository/post.go
+++ b/domain/mock_repository/post.go
@@ -78,18 +78,18 @@ func (mr *MockPostMockRecorder) FindByPermalink(permalink interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByPermalink", reflect.TypeOf((*MockPost)(nil).FindByPermalink), permalink)
 }
 
-// Store mocks base method
-func (m *MockPost) Store(post *entity.Post) error {
+// Create mocks base method
+func (m *MockPost) Create(post *entity.Post) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Store", post)
+	ret := m.ctrl.Call(m, "Create", post)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Store indicates an expected call of Store
-func (mr *MockPostMockRecorder) Store(post interface{}) *gomock.Call {
+// Create indicates an expected call of Create
+func (mr *MockPostMockRecorder) Create(post interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Store", reflect.TypeOf((*MockPost)(nil).Store), post)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockPost)(nil).Create), post)
 }
 
 // Update mocks base method

--- a/domain/mock_repository/posts_tags.go
+++ b/domain/mock_repository/posts_tags.go
@@ -5,9 +5,10 @@
 package mock_repository
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	entity "github.com/masibw/blog-server/domain/entity"
-	reflect "reflect"
 )
 
 // MockPostsTags is a mock of PostsTags interface
@@ -51,7 +52,7 @@ func (mr *MockPostsTagsMockRecorder) FindByPostIDAndTagName(postID, tagName inte
 // Store mocks base method
 func (m *MockPostsTags) Store(postsTags *entity.PostsTags) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Store", postsTags)
+	ret := m.ctrl.Call(m, "Create", postsTags)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
@@ -59,7 +60,7 @@ func (m *MockPostsTags) Store(postsTags *entity.PostsTags) error {
 // Store indicates an expected call of Store
 func (mr *MockPostsTagsMockRecorder) Store(postsTags interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Store", reflect.TypeOf((*MockPostsTags)(nil).Store), postsTags)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockPostsTags)(nil).Store), postsTags)
 }
 
 // Delete mocks base method

--- a/domain/mock_repository/tag.go
+++ b/domain/mock_repository/tag.go
@@ -5,9 +5,10 @@
 package mock_repository
 
 import (
+	reflect "reflect"
+
 	gomock "github.com/golang/mock/gomock"
 	entity "github.com/masibw/blog-server/domain/entity"
-	reflect "reflect"
 )
 
 // MockTag is a mock of Tag interface
@@ -81,7 +82,7 @@ func (mr *MockTagMockRecorder) FindByName(name interface{}) *gomock.Call {
 // Store mocks base method
 func (m *MockTag) Store(post *entity.Tag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Store", post)
+	ret := m.ctrl.Call(m, "Create", post)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
@@ -89,7 +90,7 @@ func (m *MockTag) Store(post *entity.Tag) error {
 // Store indicates an expected call of Store
 func (mr *MockTagMockRecorder) Store(post interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Store", reflect.TypeOf((*MockTag)(nil).Store), post)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockTag)(nil).Store), post)
 }
 
 // Delete mocks base method

--- a/domain/repository/post.go
+++ b/domain/repository/post.go
@@ -6,7 +6,7 @@ type Post interface {
 	FindByID(id string) (*entity.Post, error)
 	FindAll(offset, pageSize int, conditions string, params []interface{}) ([]*entity.Post, error)
 	FindByPermalink(permalink string) (*entity.Post, error)
-	Store(post *entity.Post) error
+	Create(post *entity.Post) error
 	Update(post *entity.Post) error
 	Delete(id string) error
 }

--- a/usecase/post.go
+++ b/usecase/post.go
@@ -18,30 +18,15 @@ func NewPostUseCase(postRepository repository.Post) *PostUseCase {
 	return &PostUseCase{postRepository: postRepository}
 }
 
-func (p *PostUseCase) StorePost(postDTO *dto.PostDTO) (*dto.PostDTO, error) {
+func (p *PostUseCase) CreatePost() (*dto.PostDTO, error) {
 	var post *entity.Post
 	var err error
-	post, err = p.postRepository.FindByPermalink(postDTO.Permalink)
-	if err != nil && !errors.Is(err, entity.ErrPostNotFound) {
-		return nil, fmt.Errorf("store post title=%v: %w", postDTO.Title, err)
-	}
-	if post != nil {
-		return nil, fmt.Errorf("store post permalink=%v: %w", postDTO.Permalink, entity.ErrPermalinkAlreadyExisted)
-	}
 
-	post = entity.NewPost(
-		postDTO.Title,
-		postDTO.ThumbnailURL,
-		postDTO.Content,
-		postDTO.Permalink,
-		*postDTO.IsDraft,
-	)
-	if !post.IsDraft {
-		post.PublishedAt = flextime.Now()
-	}
-	err = p.postRepository.Store(post)
+	post = entity.NewPost()
+
+	err = p.postRepository.Create(post)
 	if err != nil {
-		return nil, fmt.Errorf("store post title=%v: %w", postDTO.Title, err)
+		return nil, fmt.Errorf("create new post: %w", err)
 	}
 
 	return post.ConvertToDTO(), nil

--- a/usecase/post_test.go
+++ b/usecase/post_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/masibw/blog-server/constant"
+
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/Songmu/flextime"
@@ -28,54 +30,15 @@ func TestPostUseCase_StorePost(t *testing.T) { // nolint:gocognit
 
 	tests := []struct {
 		name                  string
-		postDTO               *dto.PostDTO
 		prepareMockPostRepoFn func(mock *mock_repository.MockPost)
 		wantErr               error
 	}{
 		{
 			name: "新規の投稿を保存し、その投稿を返す",
-			postDTO: &dto.PostDTO{
-				Title:        "new_post",
-				ThumbnailURL: "new_thumbnail_url",
-				Content:      "new_content",
-				Permalink:    "new_permalink",
-				IsDraft:      func() *bool { b := true; return &b }(),
-			},
 			prepareMockPostRepoFn: func(mock *mock_repository.MockPost) {
-				mock.EXPECT().FindByPermalink(gomock.Any()).Return(nil, entity.ErrPostNotFound)
-				mock.EXPECT().Store(gomock.Any()).Return(nil)
+				mock.EXPECT().Create(gomock.Any()).Return(nil)
 			},
 			wantErr: nil,
-		},
-		{
-			name: "IsDraftがfalseであればPublishedAtが登録されていること",
-			postDTO: &dto.PostDTO{
-				Title:        "new_post",
-				ThumbnailURL: "new_thumbnail_url",
-				Content:      "new_content",
-				Permalink:    "new_permalink",
-				IsDraft:      func() *bool { b := false; return &b }(),
-			},
-			prepareMockPostRepoFn: func(mock *mock_repository.MockPost) {
-				mock.EXPECT().FindByPermalink(gomock.Any()).Return(nil, entity.ErrPostNotFound)
-				mock.EXPECT().Store(gomock.Any()).Return(nil)
-			},
-			wantErr: nil,
-		},
-		{
-			name: "パーマリンクが登録済みの場合ErrPermalinkAlreadyExistedエラーを返す",
-			postDTO: &dto.PostDTO{
-				Title:        "new_post",
-				ThumbnailURL: "new_thumbnail_url",
-				Content:      "new_content",
-				Permalink:    "new_permalink",
-				IsDraft:      func() *bool { b := true; return &b }(),
-			},
-			prepareMockPostRepoFn: func(mock *mock_repository.MockPost) {
-				mock.EXPECT().FindByPermalink("new_permalink").Return(&entity.Post{}, nil)
-				mock.EXPECT().Store(gomock.Any()).AnyTimes().Return(nil)
-			},
-			wantErr: entity.ErrPermalinkAlreadyExisted,
 		},
 	}
 
@@ -89,45 +52,26 @@ func TestPostUseCase_StorePost(t *testing.T) { // nolint:gocognit
 				postRepository: mr,
 			}
 
-			got, err := p.StorePost(tt.postDTO)
+			got, err := p.CreatePost()
 			if !errors.Is(err, tt.wantErr) {
-				t.Errorf("StorePost() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("CreatePost() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
 			if errors.Is(err, entity.ErrPermalinkAlreadyExisted) {
 				if got == nil {
 					return
 				}
-				t.Errorf("StorePost() got = %v, want = nil", got)
+				t.Errorf("CreatePost() got = %v, want = nil", got)
 			}
 
 			if got.ID == "" {
-				t.Errorf("StorePost() ID nil want UULD")
+				t.Errorf("CreatePost() ID nil want UULD")
+			}
+			if got.ThumbnailURL != constant.DefaultThumbnailURL {
+				t.Errorf("CreatePost() ThumbnailURL is not default")
 			}
 			if got.CreatedAt.Unix() == 0 || got.UpdatedAt.Unix() == 0 {
-				t.Errorf("StorePost() time.Time field did not filled with value")
-			}
-
-			if got.ThumbnailURL != tt.postDTO.ThumbnailURL {
-				t.Errorf("StorePost() ThumbnailURL does not match got: %v, want: %v", got, tt.postDTO)
-			}
-
-			if got.Title != tt.postDTO.Title {
-				t.Errorf("StorePost() Title does not match got: %v, want: %v", got, tt.postDTO)
-			}
-			if got.Content != tt.postDTO.Content {
-				t.Errorf("StorePost() Content does not match got: %v, want: %v", got, tt.postDTO)
-			}
-			if got.Permalink != tt.postDTO.Permalink {
-				t.Errorf("StorePost() Permalink does not match got: %v, want: %v", got, tt.postDTO)
-			}
-
-			if *got.IsDraft != *tt.postDTO.IsDraft {
-				t.Errorf("StorePost() IsDraft does not match got: %v, want: %v", got, tt.postDTO)
-			}
-
-			if !*tt.postDTO.IsDraft && got.PublishedAt.IsZero() {
-				t.Errorf("StorePost() PublishedAt does not set got: %v, want: %v", got.PublishedAt, flextime.Now())
+				t.Errorf("CreatePost() time.Time field did not filled with value")
 			}
 
 		})

--- a/web/handler/post.go
+++ b/web/handler/post.go
@@ -28,19 +28,9 @@ func NewPostHandler(postUC *usecase.PostUseCase) *PostHandler {
 // StorePost は POST /posts に対応するハンドラーです。
 func (p *PostHandler) StorePost(c *gin.Context) {
 	logger := log.GetLogger()
-	postDTO := &dto.PostDTO{}
-	if err := c.ShouldBindJSON(postDTO); err != nil {
-		logger.Errorf("failed to bind", err)
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-	post, err := p.postUC.StorePost(postDTO)
+
+	post, err := p.postUC.CreatePost()
 	if err != nil {
-		if errors.Is(err, entity.ErrPermalinkAlreadyExisted) {
-			logger.Debugf("store post already existed", err)
-			c.JSON(http.StatusBadRequest, gin.H{"error": entity.ErrPermalinkAlreadyExisted.Error()})
-			return
-		}
 		logger.Errorf("store post", err)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": entity.ErrInternalServerError.Error()})
 		return

--- a/web/handler/post_test.go
+++ b/web/handler/post_test.go
@@ -29,53 +29,18 @@ func TestPostHandler_StorePost(t *testing.T) {
 		{
 			name: "正常に投稿を保存できる",
 			prepareMockPostRepoFn: func(mock *mock_repository.MockPost) {
-				mock.EXPECT().FindByPermalink(gomock.Any()).Return(nil, entity.ErrPostNotFound)
-				mock.EXPECT().Store(gomock.Any()).Return(nil)
+				mock.EXPECT().Create(gomock.Any()).Return(nil)
 			},
-			body: `{
-				"title" : "new_post",
-				"thumbnailUrl" : "new_thumbnail_url",
-				"content" : "new_content",
-				"permalink" : "new_permalink",
-				"isDraft" : false
-			}`,
+			body:     ``,
 			wantCode: http.StatusCreated,
-		},
-		{
-			name: "postDTOが満たされない時はStatusBadRequestエラーが返る",
-			prepareMockPostRepoFn: func(mock *mock_repository.MockPost) {
-			},
-			body:     "",
-			wantCode: http.StatusBadRequest,
 		},
 		{
 			name: "保存に失敗した時はStatusInternalServerErrorエラーが返る",
 			prepareMockPostRepoFn: func(mock *mock_repository.MockPost) {
-				mock.EXPECT().FindByPermalink("new_permalink").Return(nil, nil)
-				mock.EXPECT().Store(gomock.Any()).Return(errors.New("dummy error"))
+				mock.EXPECT().Create(gomock.Any()).Return(errors.New("dummy error"))
 			},
-			body: `{
-				"title" : "new_post",
-				"thumbnailUrl" : "new_thumbnail_url",
-				"content" : "new_content",
-				"permalink" : "new_permalink",
-				"isDraft" : false
-			}`,
+			body:     ``,
 			wantCode: http.StatusInternalServerError,
-		},
-		{
-			name: "保存に失敗した時はStatusBadRequestエラーが返る",
-			prepareMockPostRepoFn: func(mock *mock_repository.MockPost) {
-				mock.EXPECT().FindByPermalink("new_permalink").Return(&entity.Post{}, nil)
-			},
-			body: `{
-				"title" : "new_post",
-				"thumbnailUrl" : "new_thumbnail_url",
-				"content" : "new_content",
-				"permalink" : "new_permalink",
-				"isDraft" : false
-			}`,
-			wantCode: http.StatusBadRequest,
 		},
 	}
 	for _, tt := range tests {
@@ -101,7 +66,7 @@ func TestPostHandler_StorePost(t *testing.T) {
 			}
 			p.StorePost(c)
 			if w.Code != tt.wantCode {
-				t.Errorf("StorePost() code = %d, want = %d", w.Code, tt.wantCode)
+				t.Errorf("CreatePost() code = %d, want = %d", w.Code, tt.wantCode)
 			}
 		})
 	}


### PR DESCRIPTION
新規投稿作成を空の投稿を作成するだけにしました

名前をStore* からCreate* に変更しました

新規作成ボタンを押してエディタを開くタイミングで新しい投稿を作成する想定です
その後は全てUpdateで保存，更新します

IDとデフォルトのサムネイルURLを入れて返します
TODO
- デフォルトURLを設定する