### PR TITLE
パーマリンクが空の場合は重複を許す，Updateの時にzero値も更新できるように

### DIFF
--- a/database/post.go
+++ b/database/post.go
@@ -52,7 +52,8 @@ func (r *PostRepository) Create(post *entity.Post) error {
 }
 
 func (r *PostRepository) Update(post *entity.Post) error {
-	if err := r.db.Updates(post).Error; err != nil {
+
+	if err := r.db.Select("*").Updates(post).Error; err != nil {
 		return fmt.Errorf("update post: %w", err)
 	}
 	return nil

--- a/usecase/post.go
+++ b/usecase/post.go
@@ -71,7 +71,7 @@ func (p *PostUseCase) UpdatePost(postDTO *dto.PostDTO) (*dto.PostDTO, error) {
 	}
 
 	// 更新する投稿と違うIDを持ち，既に更新先Permalinkを持つ投稿があるとエラー
-	if permalinkPost != nil && permalinkPost.ID != postDTO.ID {
+	if permalinkPost != nil && permalinkPost.ID != postDTO.ID && postDTO.Permalink != "" {
 		return nil, fmt.Errorf("update post permalink=%v: %w", postDTO.Permalink, entity.ErrPermalinkAlreadyExisted)
 	}
 


### PR DESCRIPTION
タイトル通り
gormはデフォルトだとzero値のカラムは更新してくれなかった