### PR TITLE
リソースの全件数を返すように

### DIFF
--- a/database/post.go
+++ b/database/post.go
@@ -81,3 +81,14 @@ func (r *PostRepository) Delete(id string) error {
 	}
 	return nil
 }
+
+func (r *PostRepository) Count(condition string, params []interface{}) (count int, err error) {
+	var count64 int64
+	if err = r.db.Model(&entity.Post{}).Distinct().Where(condition, params...).Joins("LEFT JOIN posts_tags on posts_tags.post_id = posts.id").Joins("LEFT JOIN tags on posts_tags.tag_id = tags.id").Count(&count64).Error; err != nil {
+		err = fmt.Errorf("find all posts: %w", err)
+		return
+	}
+	// int64を溢れることは運用的にないのでキャストしてしまう
+	count = int(count64)
+	return
+}

--- a/database/tag.go
+++ b/database/tag.go
@@ -73,3 +73,14 @@ func (r *TagRepository) Delete(id string) error {
 	}
 	return nil
 }
+
+func (r *TagRepository) Count() (count int, err error) {
+	var count64 int64
+	if err = r.db.Model(&entity.Tag{}).Distinct().Count(&count64).Error; err != nil {
+		err = fmt.Errorf("find all posts: %w", err)
+		return
+	}
+	// int64を溢れることは運用的にないのでキャストしてしまう
+	count = int(count64)
+	return
+}

--- a/domain/mock_repository/post.go
+++ b/domain/mock_repository/post.go
@@ -5,10 +5,9 @@
 package mock_repository
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	entity "github.com/masibw/blog-server/domain/entity"
+	reflect "reflect"
 )
 
 // MockPost is a mock of Post interface
@@ -96,7 +95,7 @@ func (mr *MockPostMockRecorder) Create(post interface{}) *gomock.Call {
 // Update mocks base method
 func (m *MockPost) Update(post *entity.Post) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateLastLoggedinAt", post)
+	ret := m.ctrl.Call(m, "Update", post)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
@@ -104,7 +103,7 @@ func (m *MockPost) Update(post *entity.Post) error {
 // Update indicates an expected call of Update
 func (mr *MockPostMockRecorder) Update(post interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLastLoggedinAt", reflect.TypeOf((*MockPost)(nil).Update), post)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockPost)(nil).Update), post)
 }
 
 // Delete mocks base method
@@ -119,4 +118,19 @@ func (m *MockPost) Delete(id string) error {
 func (mr *MockPostMockRecorder) Delete(id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockPost)(nil).Delete), id)
+}
+
+// Count mocks base method
+func (m *MockPost) Count(condition string, params []interface{}) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Count", condition, params)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Count indicates an expected call of Count
+func (mr *MockPostMockRecorder) Count(condition, params interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockPost)(nil).Count), condition, params)
 }

--- a/domain/mock_repository/tag.go
+++ b/domain/mock_repository/tag.go
@@ -5,10 +5,9 @@
 package mock_repository
 
 import (
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	entity "github.com/masibw/blog-server/domain/entity"
+	reflect "reflect"
 )
 
 // MockTag is a mock of Tag interface
@@ -80,17 +79,17 @@ func (mr *MockTagMockRecorder) FindByName(name interface{}) *gomock.Call {
 }
 
 // Store mocks base method
-func (m *MockTag) Store(post *entity.Tag) error {
+func (m *MockTag) Store(tag *entity.Tag) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", post)
+	ret := m.ctrl.Call(m, "Store", tag)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Store indicates an expected call of Store
-func (mr *MockTagMockRecorder) Store(post interface{}) *gomock.Call {
+func (mr *MockTagMockRecorder) Store(tag interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockTag)(nil).Store), post)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Store", reflect.TypeOf((*MockTag)(nil).Store), tag)
 }
 
 // Delete mocks base method
@@ -105,4 +104,19 @@ func (m *MockTag) Delete(id string) error {
 func (mr *MockTagMockRecorder) Delete(id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockTag)(nil).Delete), id)
+}
+
+// Count mocks base method
+func (m *MockTag) Count() (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Count")
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Count indicates an expected call of Count
+func (mr *MockTagMockRecorder) Count() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockTag)(nil).Count))
 }

--- a/domain/repository/post.go
+++ b/domain/repository/post.go
@@ -9,4 +9,5 @@ type Post interface {
 	Create(post *entity.Post) error
 	Update(post *entity.Post) error
 	Delete(id string) error
+	Count(condition string, params []interface{}) (int, error)
 }

--- a/domain/repository/tag.go
+++ b/domain/repository/tag.go
@@ -8,4 +8,5 @@ type Tag interface {
 	FindByName(name string) (*entity.Tag, error)
 	Store(tag *entity.Tag) error
 	Delete(id string) error
+	Count() (int, error)
 }

--- a/usecase/post.go
+++ b/usecase/post.go
@@ -91,11 +91,17 @@ func (p *PostUseCase) UpdatePost(postDTO *dto.PostDTO) (*dto.PostDTO, error) {
 	return post.ConvertToDTO(), nil
 }
 
-func (p *PostUseCase) GetPosts(offset, pageSize int, condition string, params []interface{}, sortCondition string) (postDTOs []*dto.PostDTO, err error) {
+func (p *PostUseCase) GetPosts(offset, pageSize int, condition string, params []interface{}, sortCondition string) (postDTOs []*dto.PostDTO, count int, err error) {
 	var posts []*entity.Post
 	posts, err = p.postRepository.FindAll(offset, pageSize, condition, params, sortCondition)
 	if err != nil {
 		err = fmt.Errorf("get posts: %w", err)
+		return
+	}
+
+	count, err = p.postRepository.Count(condition, params)
+	if err != nil {
+		err = fmt.Errorf("count posts: %w", err)
 		return
 	}
 

--- a/usecase/post_test.go
+++ b/usecase/post_test.go
@@ -380,6 +380,7 @@ func TestPostUseCase_GetPosts(t *testing.T) {
 			name: "postDTOsを返すこと",
 			prepareMockPostRepoFn: func(mock *mock_repository.MockPost) {
 				mock.EXPECT().FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(existsPosts, nil)
+				mock.EXPECT().Count(gomock.Any(), gomock.Any()).Return(len(existsPosts), nil)
 			},
 			want: []*dto.PostDTO{
 				{
@@ -428,10 +429,13 @@ func TestPostUseCase_GetPosts(t *testing.T) {
 			}
 
 			// このGetPostsの責務はパラメータを受け取ってpostDTOsを返すだけなのでパラメータの中身はなんでも良い(はず)
-			got, err := p.GetPosts(0, 0, "", []interface{}{}, "")
+			got, count, err := p.GetPosts(0, 0, "", []interface{}{}, "")
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetPosts() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if diff := cmp.Diff(len(tt.want), count); diff != "" {
+				t.Errorf("GetPosts() mismatch (-want +got):\n%s", cmp.Diff(tt.want, got))
 			}
 
 			if diff := cmp.Diff(tt.want, got); diff != "" {

--- a/usecase/tag.go
+++ b/usecase/tag.go
@@ -39,14 +39,18 @@ func (p *TagUseCase) StoreTag(tagDTO *dto.TagDTO) (*dto.TagDTO, error) {
 	return tag.ConvertToDTO(), nil
 }
 
-func (p *TagUseCase) GetTags(offset, pageSize int) (tagDTOs []*dto.TagDTO, err error) {
+func (p *TagUseCase) GetTags(offset, pageSize int) (tagDTOs []*dto.TagDTO, count int, err error) {
 	var tags []*entity.Tag
 	tags, err = p.tagRepository.FindAll(offset, pageSize)
 	if err != nil {
 		err = fmt.Errorf("get tags: %w", err)
 		return
 	}
-
+	count, err = p.tagRepository.Count()
+	if err != nil {
+		err = fmt.Errorf("count tags: %w", err)
+		return
+	}
 	for _, tag := range tags {
 		tagDTOs = append(tagDTOs, tag.ConvertToDTO())
 	}

--- a/usecase/tag_test.go
+++ b/usecase/tag_test.go
@@ -123,6 +123,7 @@ func TestTagUseCase_GetTags(t *testing.T) {
 			name: "tagDTOsを返すこと",
 			prepareMockTagRepoFn: func(mock *mock_repository.MockTag) {
 				mock.EXPECT().FindAll(gomock.Any(), gomock.Any()).Return(existsTags, nil)
+				mock.EXPECT().Count().Return(len(existsTags), nil)
 			},
 			want: []*dto.TagDTO{
 				{
@@ -161,10 +162,14 @@ func TestTagUseCase_GetTags(t *testing.T) {
 			}
 
 			// このGetTagsの責務はパラメータを受け取ってtagDTOsを返すだけなのでパラメータの中身はなんでも良い(はず)
-			got, err := p.GetTags(0, 0)
+			got, count, err := p.GetTags(0, 0)
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetTags() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if diff := cmp.Diff(len(tt.want), count); diff != "" {
+				t.Errorf("GetTags() mismatch (-want +got):\n%s", cmp.Diff(tt.want, got))
 			}
 
 			if diff := cmp.Diff(tt.want, got); diff != "" {

--- a/web/handler/post.go
+++ b/web/handler/post.go
@@ -227,7 +227,7 @@ func (p *PostHandler) GetPosts(c *gin.Context) {
 	}
 
 	condition := strings.Join(conditions, " AND ")
-	posts, err := p.postUC.GetPosts(offset, pageSize, condition, params, sortCondition)
+	posts, count, err := p.postUC.GetPosts(offset, pageSize, condition, params, sortCondition)
 	if err != nil {
 		if errors.Is(err, entity.ErrPostNotFound) {
 			logger.Debug("get posts not found", err)
@@ -238,9 +238,9 @@ func (p *PostHandler) GetPosts(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": entity.ErrInternalServerError.Error()})
 		return
 	}
-
 	c.JSON(http.StatusOK, gin.H{
 		"posts": posts,
+		"count": count,
 	})
 }
 

--- a/web/handler/post_test.go
+++ b/web/handler/post_test.go
@@ -348,6 +348,7 @@ func TestPostHandler_GetPosts(t *testing.T) {
 			name: "正常に投稿を取得できる",
 			prepareMockPostRepoFn: func(mock *mock_repository.MockPost) {
 				mock.EXPECT().FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(existsPosts, nil)
+				mock.EXPECT().Count(gomock.Any(), gomock.Any()).Return(len(existsPosts), nil)
 			},
 			params:   nil,
 			wantCode: http.StatusOK,
@@ -372,6 +373,7 @@ func TestPostHandler_GetPosts(t *testing.T) {
 			name: "ページングを指定した時も正しく取得できる",
 			prepareMockPostRepoFn: func(mock *mock_repository.MockPost) {
 				mock.EXPECT().FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(existsPosts[1:], nil)
+				mock.EXPECT().Count(gomock.Any(), gomock.Any()).Return(len(existsPosts), nil)
 			},
 			params: []struct {
 				name  string
@@ -391,6 +393,7 @@ func TestPostHandler_GetPosts(t *testing.T) {
 			name: "tagを指定した時も正しく取得できる",
 			prepareMockPostRepoFn: func(mock *mock_repository.MockPost) {
 				mock.EXPECT().FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(existsPosts[1:], nil)
+				mock.EXPECT().Count(gomock.Any(), gomock.Any()).Return(len(existsPosts), nil)
 			},
 			params: []struct {
 				name  string
@@ -406,6 +409,7 @@ func TestPostHandler_GetPosts(t *testing.T) {
 			name: "is-draftを指定した時も正しく取得できる",
 			prepareMockPostRepoFn: func(mock *mock_repository.MockPost) {
 				mock.EXPECT().FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(existsPosts[1:], nil)
+				mock.EXPECT().Count(gomock.Any(), gomock.Any()).Return(len(existsPosts), nil)
 			},
 			params: []struct {
 				name  string
@@ -473,6 +477,7 @@ func TestPostHandler_GetPosts(t *testing.T) {
 					return existsPosts[i].CreatedAt.After(existsPosts[j].CreatedAt)
 				})
 				mock.EXPECT().FindAll(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), "created_at desc").Return(existsPosts, nil)
+				mock.EXPECT().Count(gomock.Any(), gomock.Any()).Return(len(existsPosts), nil)
 			},
 			params: []struct {
 				name  string

--- a/web/handler/tag.go
+++ b/web/handler/tag.go
@@ -76,7 +76,7 @@ func (p *TagHandler) GetTags(c *gin.Context) {
 
 		offset = (page - 1) * pageSize
 	}
-	tags, err := p.tagUC.GetTags(offset, pageSize)
+	tags, count, err := p.tagUC.GetTags(offset, pageSize)
 	if err != nil {
 		if errors.Is(err, entity.ErrTagNotFound) {
 			logger.Debug("get tags not found", err)
@@ -89,7 +89,8 @@ func (p *TagHandler) GetTags(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"tags": tags,
+		"tags":  tags,
+		"count": count,
 	})
 }
 

--- a/web/handler/tag_test.go
+++ b/web/handler/tag_test.go
@@ -130,6 +130,7 @@ func TestTagHandler_GetTags(t *testing.T) {
 			name: "正常にタグを取得できる",
 			prepareMockTagRepoFn: func(mock *mock_repository.MockTag) {
 				mock.EXPECT().FindAll(gomock.Any(), gomock.Any()).Return(existsTags, nil)
+				mock.EXPECT().Count().Return(len(existsTags), nil)
 			},
 			params:   nil,
 			wantCode: http.StatusOK,
@@ -146,6 +147,7 @@ func TestTagHandler_GetTags(t *testing.T) {
 			name: "タグの取得に失敗した場合はStatusInternalServerErrorエラーが返る",
 			prepareMockTagRepoFn: func(mock *mock_repository.MockTag) {
 				mock.EXPECT().FindAll(gomock.Any(), gomock.Any()).Return(nil, errors.New("dummy error"))
+
 			},
 			params:   nil,
 			wantCode: http.StatusInternalServerError,
@@ -154,6 +156,7 @@ func TestTagHandler_GetTags(t *testing.T) {
 			name: "ページングを指定した時も正しく取得できる",
 			prepareMockTagRepoFn: func(mock *mock_repository.MockTag) {
 				mock.EXPECT().FindAll(gomock.Any(), gomock.Any()).Return(existsTags[1:], nil)
+				mock.EXPECT().Count().Return(len(existsTags), nil)
 			},
 			params: []struct {
 				name  string


### PR DESCRIPTION
`GET /posts`と`GET /tags`の時に全件数を一緒に返すように
close #57 