### PR TITLE
https-portalから素のNginxへ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 
 # git管理するもの
 !.env.test
+
+
+*.pem

--- a/build/nginx/conf/mesimasi.com.conf
+++ b/build/nginx/conf/mesimasi.com.conf
@@ -1,0 +1,40 @@
+upstream backend{
+    server app:8080;
+}
+
+upstream frontend{
+    server front:3000;
+}
+
+
+server {
+    listen 443 ssl http2;
+    server_name mesimasi.com;
+
+    ssl_certificate /etc/ssl/certs/cert.pem;
+    ssl_certificate_key /etc/ssl/private/key.pem;
+
+    ssl_protocols       TLSv1 TLSv1.1 TLSv1.2;
+    ssl_session_cache shared:SSL:50m;
+    ssl_ciphers ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA:ECDHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA;
+    ssl_prefer_server_ciphers on;
+    ssl_session_timeout 10m;
+
+    ssl_dhparam /etc/nginx/ssl/dhparam.pem;
+
+    location /api{
+       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+       proxy_set_header Host $http_host;
+       proxy_redirect off;
+       proxy_set_header X-Forwarded-Proto $scheme;
+       proxy_pass http://backend;
+    }
+
+    location / {
+       proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+       proxy_set_header Host $http_host;
+       proxy_redirect off;
+       proxy_set_header X-Forwarded-Proto $scheme;
+       proxy_pass http://frontend;
+    }
+}

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   nginx:
-    image: steveltn/https-portal:1.17.5
+    image: nginx:1.19.9-alpine
     restart: always
     links:
       - app:app
@@ -10,10 +10,10 @@ services:
       - "443:443"
     volumes:
       # Nginxの設定ファイルを上書きする
-      - ./build/nginx/conf/blog.local.ssl.conf.erb:/var/lib/nginx-conf/blog.local.ssl.conf.erb:ro
-    environment:
-      STAGE: local
-      DOMAINS: 'blog.local => https://blog.local'
+      - ./build/nginx/conf/mesimasi.com.conf:/etc/nginx/conf.d/mesimasi.com.conf:ro
+      - ./build/nginx/conf/key.pem:/etc/ssl/private/key.pem:ro
+      - ./build/nginx/conf/cert.pem:/etc/ssl/certs/cert.pem:ro
+      - ./build/nginx/conf/dhparam.pem:/etc/nginx/ssl/dhparam.pem
     networks:
       - blog-network
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   nginx:
-    image: steveltn/https-portal:1.17.5
+    image: nginx:1.19.9-alpine
     restart: always
     links:
       - app:app
@@ -10,10 +10,10 @@ services:
       - "443:443"
     volumes:
       # Nginxの設定ファイルを上書きする
-      - ./build/nginx/conf/mesimasi.com.ssl.conf.erb:/var/lib/nginx-conf/mesimasi.com.conf.erb:ro
-    environment:
-      STAGE: production
-      DOMAINS: 'mesimasi.com => https://mesimasi.com'
+      - ./build/nginx/conf/mesimasi.com.conf:/etc/nginx/conf.d/mesimasi.com.conf:ro
+      - ./build/nginx/conf/key.pem:/etc/ssl/private/key.pem:ro
+      - ./build/nginx/conf/cert.pem:/etc/ssl/certs/cert.pem:ro
+      - ./build/nginx/conf/dhparam.pem:/etc/nginx/ssl/dhparam.pem
     networks:
       - blog-network
 


### PR DESCRIPTION
s3の画像取得を高速化するためにcloudflareを使用することにした．
そうなると別にhttps-portalでtls/ssl設定をする必要がなくなった(cloudflareの証明書を使えば良い)のでhttps-portalを剥がした

おそらくhttps-portalを使用していてもcloudflareのruleでmesimasi.comへはFull(strict)モードでアクセスすればリダイレクトループはおこらないが，2つの証明書を管理するメリットが特に見つからなかったので

なお，pem系はgit管理せず直接サーバーにおいている