### PR TITLE
テストの改善

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ down-test:
 test:
 	$(ENV_TEST) richgo test -v ./... -count=1
 
+
 .PHONY: lint
 lint:
 	golangci-lint run --out-format=github-actions --enable=golint,gosec,prealloc,gocognit,bodyclose,gofmt

--- a/database/helper_test.go
+++ b/database/helper_test.go
@@ -2,18 +2,49 @@ package database
 
 import (
 	"database/sql"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/golang-migrate/migrate/v4"
+
+	_ "github.com/golang-migrate/migrate/v4/database/mysql"
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+	_ "github.com/golang-migrate/migrate/v4/source/github"
+
+	"gorm.io/gorm"
 
 	"github.com/masibw/blog-server/config"
 	"github.com/masibw/blog-server/log"
 	"gorm.io/driver/mysql"
-	"gorm.io/gorm"
 	"moul.io/zapgorm2"
 )
+
+var db *gorm.DB
+
+func TestMain(m *testing.M) {
+	var err error
+	var mig *migrate.Migrate
+	mig, err = migrate.New("file://"+os.Getenv("MIGRATION_FILE"), "mysql://"+config.PureDSN())
+	if err != nil {
+		panic(err)
+	}
+	if err = mig.Up(); err != nil {
+		if !errors.Is(err, migrate.ErrNoChange) {
+			panic(err)
+		}
+	}
+
+	db = NewTestDB()
+	code := m.Run()
+	os.Exit(code)
+}
 
 func NewTestDB() *gorm.DB {
 	logger := zapgorm2.New(log.GetPureLogger())
 	logger.SetAsDefault()
-	db, err := gorm.Open(mysql.Open(config.DSN()), &gorm.Config{Logger: logger})
+	var err error
+	db, err = gorm.Open(mysql.Open(config.DSN()), &gorm.Config{Logger: logger})
 	if err != nil {
 		panic(err.Error())
 	}

--- a/database/post_test.go
+++ b/database/post_test.go
@@ -2,14 +2,10 @@ package database
 
 import (
 	"errors"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-
-	"github.com/golang-migrate/migrate/v4"
-	"github.com/masibw/blog-server/config"
 
 	_ "github.com/golang-migrate/migrate/v4/database/mysql"
 	_ "github.com/golang-migrate/migrate/v4/source/file"
@@ -18,32 +14,7 @@ import (
 	"github.com/Songmu/flextime"
 
 	"github.com/masibw/blog-server/domain/entity"
-
-	"gorm.io/gorm"
 )
-
-var db *gorm.DB
-
-func TestMain(m *testing.M) {
-	var err error
-	var mig *migrate.Migrate
-	mig, err = migrate.New("file://"+os.Getenv("MIGRATION_FILE"), "mysql://"+config.PureDSN())
-	if err != nil {
-		panic(err)
-	}
-	if err := mig.Up(); err != nil {
-		if !errors.Is(err, migrate.ErrNoChange) {
-			panic(err)
-		}
-	}
-
-	db = NewTestDB()
-	if err != nil {
-		panic(err)
-	}
-	code := m.Run()
-	os.Exit(code)
-}
 
 func TestPostRepository_FindByID(t *testing.T) {
 	tx := db.Begin()
@@ -52,7 +23,9 @@ func TestPostRepository_FindByID(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	if err := tx.Create(&entity.Post{
 		ID:           "abcdefghijklmnopqrstuvwxyz",
@@ -223,7 +196,9 @@ func TestPostRepository_FindByPermalink(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	if err := tx.Create(&entity.Post{
 		ID:           "abcdefghijklmnopqrstuvwxyz",
@@ -292,7 +267,9 @@ func TestPostRepository_FindAll(t *testing.T) { // nolint:gocognit
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	tests := []struct {
 		name           string
@@ -688,7 +665,9 @@ func TestPostRepository_Delete(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	tests := []struct {
 		name      string
@@ -752,7 +731,9 @@ func TestPostRepository_Count(t *testing.T) { // nolint:gocognit
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	tests := []struct {
 		name           string

--- a/database/posts_tags_test.go
+++ b/database/posts_tags_test.go
@@ -23,7 +23,9 @@ func TestPostsTagsRepository_FindByPostIDAndTagName(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	if err := tx.Create(&entity.Post{
 		ID:           "abcdefghijklmnopqrstuvwxy1",
@@ -112,6 +114,14 @@ func TestPostsTagsRepository_FindByPostIDAndTagName(t *testing.T) {
 
 func TestPostsTagsRepository_Store(t *testing.T) {
 	tx := db.Begin()
+	loc, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	if err := tx.Create(&entity.Post{
 		ID:           "abcdefghijklmnopqrstuvwxy1",
@@ -204,7 +214,9 @@ func TestPostsTagsRepository_Delete(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	if err := tx.Create(&entity.Post{
 		ID:           "abcdefghijklmnopqrstuvwxy1",
@@ -287,7 +299,9 @@ func TestPostsTagsRepository_DeleteByPostID(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	if err := tx.Create(&entity.Post{
 		ID:           "abcdefghijklmnopqrstuvwxy1",

--- a/database/tag_test.go
+++ b/database/tag_test.go
@@ -23,7 +23,9 @@ func TestTagRepository_FindByID(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	if err := tx.Create(&entity.Tag{
 		ID:        "abcdefghijklmnopqrstuvwxyz",
@@ -124,7 +126,9 @@ func TestTagRepository_FindAll(t *testing.T) { // nolint:gocognit
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	tests := []struct {
 		name           string
@@ -324,7 +328,9 @@ func TestTagRepository_Delete(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	tests := []struct {
 		name     string
@@ -383,7 +389,9 @@ func TestTagRepository_Count(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	tests := []struct {
 		name      string

--- a/database/tag_test.go
+++ b/database/tag_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"gorm.io/gorm"
+
 	"github.com/google/go-cmp/cmp"
 
 	_ "github.com/golang-migrate/migrate/v4/database/mysql"
@@ -322,13 +324,16 @@ func TestTagRepository_FindAll(t *testing.T) { // nolint:gocognit
 }
 
 func TestTagRepository_Delete(t *testing.T) {
-	tx := db.Begin()
+	db := NewTestDB()
 	loc, err := time.LoadLocation("Asia/Tokyo")
 	if err != nil {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
 	t.Cleanup(func() {
+		db.Exec("set foreign_key_checks = 0")
+		db.Exec("TRUNCATE table tags")
+		db.Exec("set foreign_key_checks = 1")
 		flextime.Restore()
 	})
 
@@ -363,23 +368,33 @@ func TestTagRepository_Delete(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.existTag != nil {
-				if err := tx.Create(tt.existTag).Error; err != nil {
+				if err := db.Create(tt.existTag).Error; err != nil {
 					t.Fatal(err)
 				}
 			}
 
-			r := &TagRepository{db: tx}
+			r := &TagRepository{db: db}
 			err := r.Delete(tt.ID)
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("Delete() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
-			//TODO 削除したことを確かめるテスト
+			// 本当に削除されているか確認する
+			got := &entity.Tag{}
+			if err = db.Where("id = ?", tt.ID).First(&got).Error; err != nil {
+				if !errors.Is(err, gorm.ErrRecordNotFound) {
+					t.Errorf("Delete() error = %v", err)
+				}
+			}
+
+			// gotには初期値(zero value)が入ってくる
+			// gotが初期値 & RecordNotFoundエラーじゃないとFail
+			if diff := cmp.Diff(&entity.Tag{}, got); diff != "" && !errors.Is(err, gorm.ErrRecordNotFound) {
+				t.Errorf("Delete() couldn't deleted: %v", got)
+			}
 
 		})
 	}
-
-	tx.Rollback()
 }
 
 func TestTagRepository_Count(t *testing.T) {

--- a/database/user_test.go
+++ b/database/user_test.go
@@ -25,7 +25,9 @@ func TestUserRepository_FindByID(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	if err := tx.Create(&entity.User{
 		ID:             "abcdefghijklmnopqrstuvwxyz",
@@ -194,7 +196,9 @@ func TestUserRepository_FindByMailAddress(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	if err := tx.Create(&entity.User{
 		ID:             "abcdefghijklmnopqrstuvwxyz",

--- a/domain/service/posts_tags_service_test.go
+++ b/domain/service/posts_tags_service_test.go
@@ -23,7 +23,9 @@ func TestLinkPostTags(t *testing.T) { // nolint:gocognit
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	tests := []struct {
 		name                 string
@@ -108,7 +110,10 @@ func TestLinkPostTags(t *testing.T) { // nolint:gocognit
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,9 @@ require (
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-gonic/gin v1.6.3
 	github.com/go-sql-driver/mysql v1.5.0
+	github.com/golang-migrate/migrate v3.5.4+incompatible
 	github.com/golang-migrate/migrate/v4 v4.14.1
-	github.com/golang/mock v1.4.4
+	github.com/golang/mock v1.5.0
 	github.com/google/go-cmp v0.5.1
 	github.com/microcosm-cc/bluemonday v1.0.4
 	github.com/oklog/ulid v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -125,6 +125,8 @@ github.com/gobuffalo/here v0.6.0/go.mod h1:wAG085dHOYqUpf+Ap+WOdrPTp5IYcDAs/x7PL
 github.com/gocql/gocql v0.0.0-20190301043612-f6df8288f9b4/go.mod h1:4Fw1eo5iaEhDUs8XyuhSVCVy52Jq3L+/3GJgYkwc+/0=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/golang-migrate/migrate v3.5.4+incompatible h1:R7OzwvCJTCgwapPCiX6DyBiu2czIUMDCB118gFTKTUA=
+github.com/golang-migrate/migrate v3.5.4+incompatible/go.mod h1:IsVUlFN5puWOmXrqjgGUfIRIbU7mr8oNBE2tyERd9Wk=
 github.com/golang-migrate/migrate/v4 v4.14.1 h1:qmRd/rNGjM1r3Ve5gHd5ZplytrD02UcItYNxJ3iUHHE=
 github.com/golang-migrate/migrate/v4 v4.14.1/go.mod h1:l7Ks0Au6fYHuUIxUhQ0rcVX1uLlJg54C/VvW7tvxSz0=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
@@ -140,6 +142,8 @@ github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4 h1:l75CXGRSwbaYNpl/Z2X1XIIAMSCquvXgpVZDhwEIJsc=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
+github.com/golang/mock v1.5.0 h1:jlYHihg//f7RRwuPfptm04yp4s7O6Kw8EZiVYIGcH0g=
+github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
 github.com/golang/protobuf v1.0.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -310,6 +314,7 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237 h1:HQagqIiBmr8YXawX/le3+O26N+vPPC1PtjaF3mwnook=
 github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
@@ -696,12 +701,15 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4 h1:UoveltGrhghAA7ePc+e+QYDHXrBps2PqFZiHkGR/xK8=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 modernc.org/b v1.0.0/go.mod h1:uZWcZfRj1BpYzfN9JTerzlNUnnPsV9O2ZA8JsRcubNg=
+modernc.org/db v1.0.0 h1:2c6NdCfaLnshSvY7OU09cyAY0gYXUZj4lmg5ItHyucg=
 modernc.org/db v1.0.0/go.mod h1:kYD/cO29L/29RM0hXYl4i3+Q5VojL31kTUVpVJDw0s8=
 modernc.org/file v1.0.0/go.mod h1:uqEokAEn1u6e+J45e54dsEA/pw4o7zLrA2GwyntZzjw=
 modernc.org/fileutil v1.0.0/go.mod h1:JHsWpkrk/CnVV1H/eGlFf85BEpfkrp56ro8nojIq9Q8=
 modernc.org/golex v1.0.0/go.mod h1:b/QX9oBD/LhixY6NDh+IdGv17hgB+51fET1i2kPSmvk=
+modernc.org/internal v1.0.0 h1:XMDsFDcBDsibbBnHB2xzljZ+B1yrOVLEFkKL2u15Glw=
 modernc.org/internal v1.0.0/go.mod h1:VUD/+JAkhCpvkUitlEOnhpVxCgsBI90oTzSCRcqQVSM=
 modernc.org/lldb v1.0.0/go.mod h1:jcRvJGWfCGodDZz8BPwiKMJxGJngQ/5DrRapkQnLob8=
+modernc.org/mathutil v1.0.0 h1:93vKjrJopTPrtTNpZ8XIovER7iCIH1QU7wNbOQXC60I=
 modernc.org/mathutil v1.0.0/go.mod h1:wU0vUrJsVWBZ4P6e7xtFJEhFSNsfRLJ8H458uRjg03k=
 modernc.org/ql v1.0.0/go.mod h1:xGVyrLIatPcO2C1JvI/Co8c0sr6y91HKFNy4pt9JXEY=
 modernc.org/sortutil v1.1.0/go.mod h1:ZyL98OQHJgH9IEfN71VsamvJgrtRX9Dj2gX+vH86L1k=

--- a/usecase/post_test.go
+++ b/usecase/post_test.go
@@ -26,7 +26,9 @@ func TestPostUseCase_StorePost(t *testing.T) { // nolint:gocognit
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	tests := []struct {
 		name                  string
@@ -43,7 +45,10 @@ func TestPostUseCase_StorePost(t *testing.T) { // nolint:gocognit
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			mr := mock_repository.NewMockPost(ctrl)
@@ -85,7 +90,9 @@ func TestPostUseCase_UpdatePost(t *testing.T) { // nolint:gocognit
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	tests := []struct {
 		name                  string
@@ -285,7 +292,10 @@ func TestPostUseCase_UpdatePost(t *testing.T) { // nolint:gocognit
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			mr := mock_repository.NewMockPost(ctrl)
@@ -346,7 +356,9 @@ func TestPostUseCase_GetPosts(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	existsPosts := []*entity.Post{{
 		ID:           "abcdefghijklmnopqrstuvwxyz",
@@ -419,7 +431,10 @@ func TestPostUseCase_GetPosts(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			mr := mock_repository.NewMockPost(ctrl)
@@ -452,7 +467,9 @@ func TestPostUseCase_GetPost(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	existsPost := &entity.Post{
 		ID:           "abcdefghijklmnopqrstuvwxyz",
@@ -527,7 +544,10 @@ func TestPostUseCase_GetPost(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			mr := mock_repository.NewMockPost(ctrl)
@@ -556,7 +576,9 @@ func TestPostUseCase_DeletePost(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	tests := []struct {
 		name                  string
@@ -583,7 +605,10 @@ func TestPostUseCase_DeletePost(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			mr := mock_repository.NewMockPost(ctrl)

--- a/usecase/tag_test.go
+++ b/usecase/tag_test.go
@@ -24,7 +24,9 @@ func TestTagUseCase_StoreTag(t *testing.T) { // nolint:gocognit
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	tests := []struct {
 		name                 string
@@ -57,7 +59,10 @@ func TestTagUseCase_StoreTag(t *testing.T) { // nolint:gocognit
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			mr := mock_repository.NewMockTag(ctrl)
@@ -99,7 +104,9 @@ func TestTagUseCase_GetTags(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	existsTags := []*entity.Tag{{
 		ID:        "abcdefghijklmnopqrstuvwxyz",
@@ -179,7 +186,10 @@ func TestTagUseCase_GetTags(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			mr := mock_repository.NewMockTag(ctrl)
@@ -213,7 +223,9 @@ func TestTagUseCase_GetTag(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	existsTag := &entity.Tag{
 		ID:        "abcdefghijklmnopqrstuvwxyz",
@@ -255,7 +267,10 @@ func TestTagUseCase_GetTag(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			mr := mock_repository.NewMockTag(ctrl)
@@ -284,7 +299,9 @@ func TestTagUseCase_DeleteTag(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	tests := []struct {
 		name                 string
@@ -311,7 +328,10 @@ func TestTagUseCase_DeleteTag(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			mr := mock_repository.NewMockTag(ctrl)

--- a/usecase/user_test.go
+++ b/usecase/user_test.go
@@ -24,7 +24,9 @@ func TestUserUseCase_StoreUser(t *testing.T) { // nolint:gocognit
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	tests := []struct {
 		name                  string
@@ -59,7 +61,10 @@ func TestUserUseCase_StoreUser(t *testing.T) { // nolint:gocognit
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			mr := mock_repository.NewMockUser(ctrl)
@@ -83,7 +88,9 @@ func TestUserUseCase_GetUserByMailAddress(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	existsUser := &entity.User{
 		ID:          "abcdefghijklmnopqrstuvwxyz",
@@ -127,7 +134,10 @@ func TestUserUseCase_GetUserByMailAddress(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			mr := mock_repository.NewMockUser(ctrl)
@@ -156,7 +166,9 @@ func TestUserUseCase_UpdateLastLoggedinAt(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	tests := []struct {
 		name                  string
@@ -197,7 +209,10 @@ func TestUserUseCase_UpdateLastLoggedinAt(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			mr := mock_repository.NewMockUser(ctrl)
@@ -222,7 +237,9 @@ func TestUserUseCase_DeleteUserByMailAddress(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	tests := []struct {
 		name                  string
@@ -249,7 +266,10 @@ func TestUserUseCase_DeleteUserByMailAddress(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			mr := mock_repository.NewMockUser(ctrl)

--- a/web/auth_middleware_test.go
+++ b/web/auth_middleware_test.go
@@ -28,7 +28,9 @@ func TestAuthMiddleware_Authenticate(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	tests := []struct {
 		name                  string
@@ -109,7 +111,9 @@ func TestAuthMiddleware_Authenticate(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
 			// Repositoryのモック
 			ctrl := gomock.NewController(t)
@@ -156,7 +160,10 @@ func TestAuthMiddleware_Authorize(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
+
 	tests := []struct {
 		name string
 		data interface{}
@@ -186,7 +193,9 @@ func TestAuthMiddleware_Authorize(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
 			// Repositoryのモック
 			ctrl := gomock.NewController(t)

--- a/web/handler/image_test.go
+++ b/web/handler/image_test.go
@@ -38,7 +38,9 @@ func TestImageHandler_StoreImage(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()

--- a/web/handler/post_test.go
+++ b/web/handler/post_test.go
@@ -47,7 +47,9 @@ func TestPostHandler_StorePost(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
 			// Repositoryのモック
 			ctrl := gomock.NewController(t)
@@ -270,7 +272,9 @@ func TestPostHandler_UpdatePost(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
 			// Repositoryのモック
 			ctrl := gomock.NewController(t)
@@ -310,7 +314,9 @@ func TestPostHandler_GetPosts(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	existsPosts := []*entity.Post{{
 		ID:           "abcdefghijklmnopqrstuvwxyz",
@@ -492,7 +498,9 @@ func TestPostHandler_GetPosts(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
 			// Repositoryのモック
 			ctrl := gomock.NewController(t)
@@ -536,7 +544,9 @@ func TestPostHandler_GetPost(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	existsPost := &entity.Post{
 		ID:           "abcdefghijklmnopqrstuvwxyz",
@@ -599,7 +609,10 @@ func TestPostHandler_GetPost(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+
+			t.Parallel()
 
 			// Repositoryのモック
 			ctrl := gomock.NewController(t)
@@ -642,7 +655,9 @@ func TestPostHandler_DeletePost(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	tests := []struct {
 		name                  string
@@ -676,7 +691,9 @@ func TestPostHandler_DeletePost(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
 			// Repositoryのモック
 			ctrl := gomock.NewController(t)

--- a/web/handler/tag_test.go
+++ b/web/handler/tag_test.go
@@ -67,7 +67,9 @@ func TestTagHandler_StoreTag(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
 			// Repositoryのモック
 			ctrl := gomock.NewController(t)
@@ -102,7 +104,9 @@ func TestTagHandler_GetTags(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	existsTags := []*entity.Tag{{
 		ID:        "abcdefghijklmnopqrstuvwxyz",
@@ -194,7 +198,9 @@ func TestTagHandler_GetTags(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
 			// Repositoryのモック
 			ctrl := gomock.NewController(t)
@@ -238,7 +244,9 @@ func TestTagHandler_GetTag(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	existsTag := &entity.Tag{
 		ID:        "abcdefghijklmnopqrstuvwxyz",
@@ -279,7 +287,9 @@ func TestTagHandler_GetTag(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
 			// Repositoryのモック
 			ctrl := gomock.NewController(t)
@@ -314,7 +324,9 @@ func TestTagHandler_DeleteTag(t *testing.T) {
 		t.Fatal(err)
 	}
 	flextime.Fix(time.Date(2021, 1, 22, 0, 0, 0, 0, loc))
-	defer flextime.Restore()
+	t.Cleanup(func() {
+		flextime.Restore()
+	})
 
 	tests := []struct {
 		name                 string
@@ -348,7 +360,9 @@ func TestTagHandler_DeleteTag(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
 			// Repositoryのモック
 			ctrl := gomock.NewController(t)


### PR DESCRIPTION
- database以外のテストを並列で行うように
- transactionを使うのではなくテスト後にtruncateすることで削除されたかの確認ができるように
- testのmain関数を`helper_test`へ分離